### PR TITLE
Add Bitrix connector webhook endpoints

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -25,6 +25,12 @@ app.post('/b24/events', b24.events);
 app.get('/b24/test', b24.test);
 app.get('/b24/debug', b24.debug);
 
+// Bitrix connector helper
+const connector = require('./webhooks/connector');
+app.get('/b24/connector/status', connector.status);
+app.post('/b24/connector/configure', connector.configure);
+app.post('/b24/connector/activate', connector.activate);
+
 // WhatsApp
 const wsp = require('./webhooks/whatsapp');
 app.get('/webhooks/whatsapp', wsp.getVerify);
@@ -60,6 +66,7 @@ const PORT = Number(process.env.PORT || 3000);
 app.listen(PORT, () => {
   console.log(`[b24-wsp] listo en http://localhost:${PORT}`);
   console.log(`[routes] GET/POST /b24/install | GET /b24/test | GET /b24/debug | POST /b24/events`);
+  console.log(`[routes] GET /b24/connector/status | POST /b24/connector/configure | POST /b24/connector/activate`);
   console.log(`[routes] GET /webhooks/whatsapp (challenge) | POST /webhooks/whatsapp`);
   console.log(`[routes] GET /wsp/send?to=+51...&text=...`);
 });

--- a/src/webhooks/connector.js
+++ b/src/webhooks/connector.js
@@ -1,0 +1,61 @@
+// src/webhooks/connector.js
+// Rutas para administrar el conector personalizado de Bitrix24
+
+const { call } = require('../services/b24client');
+
+/**
+ * GET /b24/connector/status
+ * Obtiene datos/configuración del conector en Bitrix24.
+ */
+async function status(req, res) {
+  try {
+    const connector = req.query.connector || process.env.CONNECTOR_CODE;
+    const line = req.query.line || process.env.OPENLINE_ID;
+    const params = { CONNECTOR: connector };
+    if (line) params.LINE = Number(line);
+    const result = await call('imconnector.connector.data.get', params);
+    res.json({ ok: true, result });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: e.message });
+  }
+}
+
+/**
+ * POST /b24/connector/configure
+ * Establece la configuración del conector.
+ */
+async function configure(req, res) {
+  try {
+    const connector = req.body.connector || process.env.CONNECTOR_CODE;
+    const line = req.body.line || process.env.OPENLINE_ID;
+    const data = req.body.data || {};
+    const result = await call('imconnector.connector.data.set', {
+      CONNECTOR: connector,
+      LINE: Number(line),
+      DATA: data
+    });
+    res.json({ ok: true, result });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: e.message });
+  }
+}
+
+/**
+ * POST /b24/connector/activate
+ * Activa el conector en Bitrix24.
+ */
+async function activate(req, res) {
+  try {
+    const connector = req.body.connector || process.env.CONNECTOR_CODE;
+    const line = req.body.line || process.env.OPENLINE_ID;
+    const params = { CONNECTOR: connector };
+    if (line) params.LINE = Number(line);
+    const result = await call('imconnector.connector.activate', params);
+    res.json({ ok: true, result });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: e.message });
+  }
+}
+
+module.exports = { status, configure, activate };
+


### PR DESCRIPTION
## Summary
- add webhook handlers to manage Bitrix connector status, configuration and activation
- expose /b24/connector routes in server

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b267f8f7ac832f802b07a0eb074bf8