### PR TITLE
feat: handle whatsapp media types

### DIFF
--- a/src/services/statusStore.js
+++ b/src/services/statusStore.js
@@ -31,7 +31,7 @@ function normalizeE164Maybe(s) {
 
 /**
  * Guarda un inbound (mensaje entrante de WhatsApp)
- * { wamid, from: '+51...', text, profileName, ts }
+ * { wamid, from: '+51...', text, profileName, ts, media? }
  */
 async function appendInbound(evt) {
   const row = {
@@ -40,7 +40,8 @@ async function appendInbound(evt) {
     from: normalizeE164Maybe(evt.from),
     text: evt.text || '',
     profileName: evt.profileName || '',
-    ts: Number(evt.ts || Date.now())
+    ts: Number(evt.ts || Date.now()),
+    media: evt.media || undefined
   };
   await appendLine(row);
   return row;


### PR DESCRIPTION
## Summary
- handle image, document and audio messages from WhatsApp webhooks
- validate media size/mime via env caps before pushing to Bitrix
- persist optional media metadata in status store

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b25228a048832faf553afd79f77005