### PR TITLE
feat: add Open Lines demo route

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,7 @@ require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
 const express = require('express');   // 👈 se había borrado, vuelve aquí
 const morgan = require('morgan');
 const fs = require('fs-extra');
+const { sendToOpenLines } = require('./services/oc');
 
 const app = express();
 app.use(express.json({ limit: '10mb' }));
@@ -56,12 +57,26 @@ app.get('/wsp/send', async (req, res) => {
   }
 });
 
+// Demo de envío a Open Lines
+app.post('/b24/imc/send-demo', async (req, res) => {
+  try {
+    const { to, text } = req.query;
+    const r = await sendToOpenLines({ userId: to, chatId: to, text: text || 'ping' });
+    console.log('[b24:imc:send-demo] ok', JSON.stringify(r));
+    res.json({ ok: true, result: r });
+  } catch (e) {
+    console.error('[b24:imc:send-demo] error', e?.response?.data || e.message || e);
+    res.status(500).json({ ok: false, error: e?.response?.data || e.message || String(e) });
+  }
+});
+
 const PORT = Number(process.env.PORT || 3000);
 app.listen(PORT, () => {
   console.log(`[b24-wsp] listo en http://localhost:${PORT}`);
   console.log(`[routes] GET/POST /b24/install | GET /b24/test | GET /b24/debug | POST /b24/events`);
   console.log(`[routes] GET /webhooks/whatsapp (challenge) | POST /webhooks/whatsapp`);
   console.log(`[routes] GET /wsp/send?to=+51...&text=...`);
+  console.log(`[routes] POST /b24/imc/send-demo?to=+51...&text=...`);
 });
 
 module.exports = app;


### PR DESCRIPTION
## Summary
- import sendToOpenLines service and expose POST `/b24/imc/send-demo`
- log new route during startup

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b267f24d44832f889be6ad11eff44c